### PR TITLE
fix(footer): stacked footer

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -3,3 +3,9 @@
  * bundles Infima by default. Infima is a CSS framework designed to
  * work well for content-centric websites.
  */
+
+ @media (max-width: 996px) {
+  .col.footer__col {
+   flex-basis: 0;
+  }
+ }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -4,8 +4,14 @@
  * work well for content-centric websites.
  */
 
- @media (max-width: 996px) {
+@media (max-width: 996px) {
   .col.footer__col {
    flex-basis: 0;
   }
- }
+}
+
+@media (max-width: 490px) {
+  .col.footer__col {
+   flex-basis: var(--ifm-col-width);
+  }
+}


### PR DESCRIPTION
Fix for #22.

Overriden flex-basis to make footer contents not appear stacked in widths smaller than 996px